### PR TITLE
Add `fields` query param to get message endpoint

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -4,6 +4,15 @@ from api import models
 from api.app import ma
 
 
+def dump_only_fields(data: dict, fields: list):
+    """
+    If fields provided, returns dict filtered by keys that in field list.
+    """
+    if not fields:
+        return data
+    return {k: v for k, v in data.items() if k in fields}
+
+
 class MessagePayloadSchema(ma.Schema):
     sender = fields.String(required=True)
     receiver = fields.String(required=True)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,7 +1,9 @@
 import pytest
+from freezegun import freeze_time
 
 from api.app import create_app, db
 from api.conf import TestingConfig
+from api.models import Message
 
 
 @pytest.yield_fixture(scope='session')
@@ -21,3 +23,12 @@ def _db(app):
 def client(app):
     with app.app_context():
         yield app.test_client()
+
+
+@pytest.fixture
+@freeze_time('2020-04-07 14:21:22.123456')
+def message(db_session):
+    message = Message(id=42, payload={"sender": "AU"})
+    db_session.add(message)
+    db_session.commit()
+    return message

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -1,18 +1,12 @@
 from datetime import datetime
 
-from freezegun import freeze_time
-
 from api.models import MessageStatus, Message
 
 
-@freeze_time('2020-04-07 14:21:22.123456')
-def test_message__can_be_created(db_session):
-    message = Message(id=42, payload={"sender": "AU"})
-    db_session.add(message)
-    db_session.commit()
-    message = db_session.query(Message).get(42)
+def test_message__can_be_created(db_session, message):
+    created = db_session.query(Message).get(message.id)
 
-    assert message.status == MessageStatus.CONFIRMED
-    assert message.payload == {"sender": "AU"}
-    assert message.created_at == datetime(2020, 4, 7, 14, 21, 22, 123456)
+    assert created.status == MessageStatus.CONFIRMED
+    assert created.payload == message.payload
+    assert created.created_at == datetime(2020, 4, 7, 14, 21, 22, 123456)
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -53,12 +53,8 @@ def test_get_message__when_missing_id__should_return_404(client, db_session):
     assert response.status_code == 404
 
 
-def test_get_message__when_exist__should_return_it(client, db_session):
-    message = Message(id=42, payload={"sender": "AU"})
-    db_session.add(message)
-    db_session.commit()
-
-    response = client.get(url_for('views.get_message', id=42))
+def test_get_message__when_exist__should_return_it(client, message):
+    response = client.get(url_for('views.get_message', id=message.id))
     assert response.status_code == 200
     assert response.json == {
         'id': 42,
@@ -66,4 +62,12 @@ def test_get_message__when_exist__should_return_it(client, db_session):
         'message': {
             'sender': 'AU'
         }
+    }
+
+
+def test_get_message__when_fields_provided__should_return_only_requested_fields(client, message):
+    response = client.get(url_for('views.get_message', id=message.id) + '?fields=status')
+    assert response.status_code == 200
+    assert response.json == {
+        'status': 'confirmed',
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ psycopg2-binary==2.8.5
 sentry_sdk[flask]==0.14.3
 apispec[yaml,validation]==3.3.0
 apispec-webframeworks==0.5.2
+webargs==6.0.0
 
 # test
 pytest==5.4.1

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -64,6 +64,14 @@ paths:
         schema:
           format: int64
           type: integer
+      - explode: false
+        in: query
+        name: fields
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
       responses:
         '200':
           content:


### PR DESCRIPTION
* Add `?fields=` query param that takes comma separated list and returns response schema based on requested fields

* Add webargs to requirements
* Update swagger docs