### PR TITLE
feat: add db migration with lambda function

### DIFF
--- a/lambda_manage.py
+++ b/lambda_manage.py
@@ -1,33 +1,16 @@
 import os
 import logging
 
-from flask_migrate import upgrade, current
+from flask_migrate import upgrade
 
-from api.app import create_app, db
+from api.app import create_app
 from api.conf import AWSProductionConfig
 
 logger = logging.getLogger(__name__)
 app = create_app(AWSProductionConfig())
 
-def dbmgmt_handler(event, context):
+def dbupgrade_handler(event, context):
 
     revision = os.getenv('DB_REVISION', 'head')
-    task = 'upgrade'
-
-    if event.get('task'):
-        task = event.get('task')
-
-    if task == 'upgrade':
-        with app.app_context():
-            upgrade(revision=revision)
-
-    elif task == 'current':
-        with app.app_context():
-            current()
-
-    return {
-        'task' : task
-    }
-
-if __name__ == "__main__":
-    dbmgmt_handler({},{})
+    with app.app_context():
+        upgrade(revision=revision)

--- a/lambda_manage.py
+++ b/lambda_manage.py
@@ -1,0 +1,33 @@
+import os
+import logging
+
+from flask_migrate import upgrade, current
+
+from api.app import create_app, db
+from api.conf import AWSProductionConfig
+
+logger = logging.getLogger(__name__)
+app = create_app(AWSProductionConfig())
+
+def dbmgmt_handler(event, context):
+
+    revision = os.getenv('DB_REVISION', 'head')
+    task = 'upgrade'
+
+    if event.get('task'):
+        task = event.get('task')
+
+    if task == 'upgrade':
+        with app.app_context():
+            upgrade(revision=revision)
+
+    elif task == 'current':
+        with app.app_context():
+            current()
+
+    return {
+        'task' : task
+    }
+
+if __name__ == "__main__":
+    dbmgmt_handler({},{})

--- a/lambda_manage.py
+++ b/lambda_manage.py
@@ -6,6 +6,9 @@ from flask_migrate import upgrade
 from api.app import create_app
 from api.conf import AWSProductionConfig
 
+'''Provides management tasks which can be invoked using AWS Lambda'''
+'''Each task you want to complete is configured with a lambda handler'''
+
 logger = logging.getLogger(__name__)
 app = create_app(AWSProductionConfig())
 

--- a/lambda_manage.py
+++ b/lambda_manage.py
@@ -1,3 +1,6 @@
+"""Provides management tasks which can be invoked using AWS Lambda.
+Each task you want to complete is configured with a lambda handler."""
+
 import os
 import logging
 
@@ -6,14 +9,12 @@ from flask_migrate import upgrade
 from api.app import create_app
 from api.conf import AWSProductionConfig
 
-'''Provides management tasks which can be invoked using AWS Lambda'''
-'''Each task you want to complete is configured with a lambda handler'''
 
 logger = logging.getLogger(__name__)
 app = create_app(AWSProductionConfig())
 
-def dbupgrade_handler(event, context):
 
+def dbupgrade_handler(event, context):
     revision = os.getenv('DB_REVISION', 'head')
     with app.app_context():
         upgrade(revision=revision)


### PR DESCRIPTION
Adds a lambda handler function which will support the use of running migrations as a basic task from an AWS lambda function

Happy to have some review from anyone, I'm sure there are better ways to do this