### PR TITLE
chore(docker): Add ability to start it both as host-based and internal network-based

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,5 +1,10 @@
+# For connecting to the host container for Windows/MacOs leave it as is
+# to connect internally set it to `postgres` and `5432` respectively
 DB_HOST=host.docker.internal
-DB_PORT=25432
+CONN_DB_PORT=25432
+HOST_BIND_DB_PORT=25432
 DB_USER=dbchannel
 DB_PASSWORD=dbchannel
 DB_NAME=dbchannel
+
+API_PORT=5000

--- a/docker-compose-shared-db.yml
+++ b/docker-compose-shared-db.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - .:/src
     environment:
-      DATABASE_URI: postgresql+psycopg2://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME
-    ports: ['5000:5000']
-    command: bash -c "cd /src && ./scripts/wait-for-it.sh $DB_HOST:$DB_PORT && ./scripts/runserver.sh"
+      DATABASE_URI: postgresql+psycopg2://$DB_USER:$DB_PASSWORD@$DB_HOST:$CONN_DB_PORT/$DB_NAME
+      API_PORT: $API_PORT
+    ports: ['$API_PORT:$API_PORT']
+    command: bash -c "cd /src && ./scripts/wait-for-it.sh $DB_HOST:$CONN_DB_PORT && ./scripts/runserver.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,16 @@ x-services:
     depends_on:
       - postgres
     environment:
-      DATABASE_URI: postgresql+psycopg2://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME
+      DATABASE_URI: postgresql+psycopg2://$DB_USER:$DB_PASSWORD@$DB_HOST:$CONN_DB_PORT/$DB_NAME
+      API_PORT: $API_PORT
     volumes:
       - .:/src
-    ports: ['5000:5000']
-
-
 
 services:
   api:
     <<: *base-api
-    command: bash -c "cd /src && ./scripts/wait-for-it.sh $DB_HOST:$DB_PORT && ./scripts/runserver.sh"
+    ports: ['$API_PORT:$API_PORT']
+    command: bash -c "cd /src && ./scripts/wait-for-it.sh $DB_HOST:$CONN_DB_PORT && ./scripts/runserver.sh"
 
   postgres:
     image: postgres:10.5
@@ -26,7 +25,7 @@ services:
       - POSTGRES_USER=$DB_USER
       - POSTGRES_PASSWORD=$DB_PASSWORD
       - POSTGRES_DB=$DB_NAME
-    ports: ['${DB_PORT}:5432']
+    ports: ['${HOST_BIND_DB_PORT}:5432']
     restart: on-failure
 
 

--- a/scripts/runserver.sh
+++ b/scripts/runserver.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python manage.py db upgrade && \
-python manage.py runserver -h 0.0.0.0
+python manage.py runserver -h 0.0.0.0 -p $API_PORT


### PR DESCRIPTION
After this I was able to start it locally and link to my local Intergov; there may be problems with it but I think together we will make it working both for all 3 target systems (win, mac and linux)