### PR TITLE
fix: docker build with src code

### DIFF
--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -5,5 +5,5 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 WORKDIR /src
 
-COPY ./requirements.txt .
+COPY ./ .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Copy the application code into the src directory so the container can be used without a volume mount. 
If a volume mount is present this will be overridden, the copy adds a little bit of time to the docker build. 

Happy to create a production docker file which does this, but feels like adding extra maintenance 